### PR TITLE
Capability to use Npub as target for split payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Split Payments - <small>[LNbits](https://github.com/lnbits/lnbits) extension</small>
-
 <small>For more about LNBits extension check [this tutorial](https://github.com/lnbits/lnbits/wiki/LNbits-Documentation#use-cases-of-lnbits)</small>
 
 ## Have payments split between multiple wallets
@@ -14,16 +13,16 @@ LNbits Split Payments extension allows for distributing payments across multiple
 
 2. Add the wallet or wallets info to split payments to
 
-![split wallets](https://i.imgur.com/5hCNWpg.png) - get the LNURLp, a LNaddress, wallet id, or an invoice key from a different wallet. It can be a completely different user on another instance/domain. You can get the wallet information on the API Info section on every wallet page\
+![split wallets](https://image.nostr.build/1ccd166649cd67dd0c85c1b4f6decec3eb0fa267a311bc7c3efec8bd165fad05.png) - get the LNURLp, a LNaddress, wallet id, or an invoice key from a different wallet. It can be a completely different user on another instance/domain. You can get the wallet information on the API Info section on every wallet page\
  ![wallet info](https://i.imgur.com/betqflC.png) - set a wallet _Alias_ for your own identification\
 
 - set how much, in percentage, this wallet will receive from every payment sent to the source wallet
 
-3. When done with adding or deleting a set of targets, click "SAVE TARGETS" to make the splits effective.
+3. When done with adding or deleting a set of targets, click "SAVE TARGETS" to make the splits effective. 
 
 4. You can have several wallets to split to, as long as the sum of the percentages is under or equal to 100%. It can only reach 100% if the targets are all internal ones.
 
-5. When the source wallet receives a payment, the extension will automatically split the corresponding values to every wallet.
+5. When the source wallet receives a payment, the extension will automatically split the corresponding values to every wallet. 
    - on receiving a 20 sats payment\
      ![get 20 sats payment](https://i.imgur.com/BKp0xvy.png)
    - source wallet gets 18 sats\
@@ -34,11 +33,12 @@ LNbits Split Payments extension allows for distributing payments across multiple
 IMPORTANT:
 
 - If you split to a LNURLp or LNaddress through the LNURLp extension make sure your receipients allow comments ! Split&Scrub add a comment in your transaction - and if it is not allowed, the split/scrub will not take place.
-- Make sure the LNURLp / LNaddress of the receipient has its min-sats set very low (e.g. 1 sat). If the wallet does not belong to you you can [check with a Decoder](https://lightningdecoder.com/), if that is the case already
+- Make sure the LNURLp / LNaddress of the receipient has its min-sats set very low (e.g. 1 sat). If the wallet does not belong to you you can [check with a Decoder](https://lightningdecoder.com/), if that is the case already 
 - Yes, there is fees - internal and external! Updating your own wallets on your own instance will not cost any fees but sending to an external instance will. Please notice that you should therefore not split up to 100% if you send to a wallet that is external (leave 1-2% reserve for routing fees!). External fees are deducted from the individual payment percentage of the receipient
 
 <img width="1148" alt="Bildschirm­foto 2023-05-01 um 22 14 36" src="https://user-images.githubusercontent.com/63317640/235534056-49296aeb-7295-4b4e-9f57-914a677f5ad4.png">
 <img width="1402" alt="Bildschirm­foto 2023-05-01 um 22 17 52" src="https://user-images.githubusercontent.com/63317640/235534063-b2734654-7c1a-48a3-b48e-32798c232b49.png">
+
 
 ## Sponsored by
 

--- a/templates/splitpayments/index.html
+++ b/templates/splitpayments/index.html
@@ -34,7 +34,7 @@
             <q-input
               dense
               outlined
-              v-model.trim="target.alias"
+              v-model="target.alias"
               label="Alias"
               :hint="t === targets.length - 1 ? 'A name to identify this target wallet locally.' : undefined"
               style="width: 150px"
@@ -42,9 +42,9 @@
 
             <q-input
               dense
-              v-model.trim="target.wallet"
+              v-model="target.wallet"
               label="Target"
-              hint="A wallet ID, invoice key, LNURLp or Lightning Address."
+              hint="A wallet ID, invoice key, LNURLp, NPUB, or Lightning Address."
               option-label="name"
               style="width: 500px"
               new-value-mode="add-unique"
@@ -118,12 +118,10 @@
             This is valid for every payment, doesn't matter how it was created.
           </p>
           <p>
-            Targets can be LNBits wallets from this LNBits instance or any valid
-            LNURL or LN Address.
+            Targets can be LNBits wallets from this LNBits instance or any valid LNURL or LN Address.
           </p>
           <p class="text-warning">
-            LNURLp and LN Addresses must allow comments > 100 chars and also
-            have a flexible amount.
+              LNURLp and LN Addresses must allow comments > 100 chars and also have a flexible amount.
           </p>
           <p>
             To remove a wallet from the targets list just press the X and save.

--- a/views_api.py
+++ b/views_api.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import List
 
+
 from fastapi import Depends
 from loguru import logger
 from starlette.exceptions import HTTPException
@@ -12,29 +13,28 @@ from . import scheduled_tasks, splitpayments_ext
 from .crud import get_targets, set_targets
 from .models import Target, TargetPutList
 
-
 @splitpayments_ext.get("/api/v1/targets")
 async def api_targets_get(
     wallet: WalletTypeInfo = Depends(require_admin_key),
 ) -> List[Target]:
-    targets = await get_targets(wallet.wallet.id)
+    targets = await get_targets(wallet.wallet.id)    
     return targets or []
-
 
 @splitpayments_ext.put("/api/v1/targets", status_code=HTTPStatus.OK)
 async def api_targets_set(
     target_put: TargetPutList,
     source_wallet: WalletTypeInfo = Depends(require_admin_key),
 ) -> None:
+    
     try:
         targets: List[Target] = []
-        for entry in target_put.targets:
+        for entry in target_put.targets:                
 
-            if entry.wallet.find("@") < 0 and entry.wallet.find("LNURL") < 0:
+            if entry.wallet.find("@") < 0 and entry.wallet.find("LNURL") < 0 and entry.wallet.find("npub") < 0:
                 wallet = await get_wallet(entry.wallet)
                 if not wallet:
                     wallet = await get_wallet_for_key(entry.wallet, "invoice")
-                    if not wallet:
+                    if not wallet:                        
                         raise HTTPException(
                             status_code=HTTPStatus.BAD_REQUEST,
                             detail=f"Invalid wallet '{entry.wallet}'.",
@@ -43,20 +43,21 @@ async def api_targets_set(
                 if wallet.id == source_wallet.wallet.id:
                     raise HTTPException(
                         status_code=HTTPStatus.BAD_REQUEST, detail="Can't split to itself."
-                    )
+                    )                        
 
             if entry.percent <= 0:
                 raise HTTPException(
                     status_code=HTTPStatus.BAD_REQUEST,
                     detail=f"Invalid percent '{entry.percent}'.",
                 )
-
+            
             targets.append(
                 Target(
                     wallet=entry.wallet,
                     source=source_wallet.wallet.id,
                     percent=entry.percent,
                     alias=entry.alias,
+                    walletName=entry.wallet,
                 )
             )
 


### PR DESCRIPTION
Added the ability to use Nostr Npubs as targets for Split Payments in response to #5 

I used existing libraries to processes websocket requests to relay:
wss://nostr-pub.wellorder.net

Now users can specify the nostr npub as the Target
![image](https://github.com/lnbits/splitpayments/assets/30268344/8c97b2ef-ed00-453b-b8b0-220e28817850)

The split payments will query the relay for the Npub and attempt to receive a lud16 address.

When payment is made to the host wallet the split payments accepts the sats and then splits based on percentages allocated:
![image](https://github.com/lnbits/splitpayments/assets/30268344/4cadf906-4535-4a5d-bce2-fd737c350101)

TODO:
- add ability for user to change relay
- finish testing and adding conditional for lud06 when lud16 is not available
