### PR TITLE
feat: pass previous memo through

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -46,7 +46,9 @@ async def on_invoice_paid(payment: Payment) -> None:
         if target.percent > 0:
             amount_msat = int(payment.amount * target.percent / 100)
             memo = (
-                f"Split payment: {target.percent}% for {target.alias or target.wallet}"
+                f"Split payment: {target.percent}% "
+                f"for {target.alias or target.wallet}"
+                f";{payment.memo};{payment.payment_hash}"
             )
 
             if "@" in target.wallet or "LNURL" in target.wallet:


### PR DESCRIPTION
closes #15 

now the memo of the payment has this form
`{memo;memo_parent_payment;payment_hash_parent_payment}