### PR TITLE
fix: prevent split payment failures from blocking remaining targets

### DIFF
--- a/migrations.py
+++ b/migrations.py
@@ -102,7 +102,7 @@ async def m003_add_id_and_tag(db: Connection):
                 "wallet": row["wallet"],
                 "source": row["source"],
                 "percent": row["percent"],
-                "tag": row["tag"],
+                "tag": "",
                 "alias": row["alias"],
             },
         )

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -6,11 +6,7 @@ function hashTargets(targets) {
 }
 
 function isTargetComplete(target) {
-  return (
-    target.wallet &&
-    target.wallet.trim() !== '' &&
-    (target.percent > 0 || target.tag != '')
-  )
+  return target.wallet && target.wallet.trim() !== '' && target.percent > 0
 }
 
 window.app = Vue.createApp({

--- a/tasks.py
+++ b/tasks.py
@@ -45,16 +45,35 @@ async def on_invoice_paid(payment: Payment) -> None:
     logger.trace(f"splitpayments: performing split payments to {len(targets)} targets")
 
     for target in targets:
-        if target.percent > 0:
+        try:
+            if target.percent <= 0:
+                continue
+
             amount_msat = int(payment.amount * target.percent / 100)
+            amount_sat = amount_msat // 1000
+            if amount_sat < 1:
+                logger.warning(
+                    f"splitpayments: skipping target {target.alias or target.wallet},"
+                    f" amount too small ({amount_msat} msat)"
+                )
+                continue
+
             memo = (
                 f"Split payment: {target.percent}% "
                 f"for {target.alias or target.wallet}"
                 f";{payment.memo};{payment.payment_hash}"
             )
 
-            if "@" in target.wallet or "LNURL" in target.wallet:
+            payment_request = None
+            if "@" in target.wallet or "lnurl" in target.wallet.lower():
                 safe_amount_msat = amount_msat - fee_reserve(amount_msat)
+                if safe_amount_msat < 1000:
+                    logger.warning(
+                        f"splitpayments: skipping LNURL target"
+                        f" {target.alias or target.wallet},"
+                        f" amount after fee reserve too small"
+                    )
+                    continue
                 payment_request = await get_lnurl_invoice(
                     target.wallet, payment.wallet_id, safe_amount_msat, memo
                 )
@@ -64,24 +83,40 @@ async def on_invoice_paid(payment: Payment) -> None:
                     target.wallet = wallet.id
                 new_payment = await create_invoice(
                     wallet_id=target.wallet,
-                    amount=int(amount_msat / 1000),
+                    amount=amount_sat,
                     internal=True,
                     memo=memo,
                 )
                 payment_request = new_payment.bolt11
 
-            extra = {**payment.extra, "splitted": True}
+            if not payment_request:
+                continue
 
-            if payment_request:
-                task = asyncio.create_task(
-                    pay_invoice_in_background(
-                        payment_request=payment_request,
-                        wallet_id=payment.wallet_id,
-                        description=memo,
-                        extra=extra,
-                    )
+            extra = {**payment.extra, "splitted": True}
+            task = asyncio.create_task(
+                pay_invoice_in_background(
+                    payment_request=payment_request,
+                    wallet_id=payment.wallet_id,
+                    description=memo,
+                    extra=extra,
                 )
-                task.add_done_callback(lambda fut: logger.success(fut.result()))
+            )
+            task.add_done_callback(_log_task_result)
+
+        except Exception as e:
+            logger.error(
+                f"splitpayments: failed to process target"
+                f" {target.alias or target.wallet}: {e}"
+            )
+
+
+def _log_task_result(fut):
+    try:
+        result = fut.result()
+        if result:
+            logger.success(result)
+    except Exception as e:
+        logger.error(f"splitpayments: background task failed: {e}")
 
 
 async def pay_invoice_in_background(payment_request, wallet_id, description, extra):

--- a/views_api.py
+++ b/views_api.py
@@ -30,7 +30,7 @@ async def api_targets_set(
         targets: list[Target] = []
         for entry in target_put.targets:
 
-            if entry.wallet.find("@") < 0 and entry.wallet.find("LNURL") < 0:
+            if entry.wallet.find("@") < 0 and "lnurl" not in entry.wallet.lower():
                 wallet = await get_wallet(entry.wallet)
                 if not wallet:
                     wallet = await get_wallet_for_key(entry.wallet)
@@ -70,6 +70,8 @@ async def api_targets_set(
 
         await set_targets(source_wallet.wallet.id, targets)
 
+    except HTTPException:
+        raise
     except Exception as ex:
         logger.warning(ex)
         raise HTTPException(


### PR DESCRIPTION
## Summary

- **Wrap per-target processing in try/except** so one failed target logs an error and continues instead of aborting all remaining splits (critical: this was silently stopping payments)
- **Make LNURL detection case-insensitive** — lowercase `lnurl1...` (the canonical bech32 form) was rejected at the API or misrouted as a wallet ID at payment time
- **Add minimum amount guard** — sub-1-sat split amounts produced 0-amount invoices that crashed `create_invoice`, which then triggered the above cascading failure
- **Add post-fee-reserve minimum for LNURL targets** — after subtracting `fee_reserve`, the amount could go negative/zero
- **Re-raise `HTTPException` before generic handler** in `api_targets_set` — validation errors (invalid wallet, self-split, bad percent, over-100%) were being swallowed by a blanket `except Exception` and returned as a generic 500 "Cannot set targets"
- **Fix migration m003** — `row["tag"]` read from a table that has no `tag` column, causing `KeyError` when migrating existing data
- **Fix `done_callback`** — replaced `lambda fut: logger.success(fut.result())` which logged `success(None)` on failure with a proper helper
- **Fix frontend `isTargetComplete`** — removed reference to deleted `tag` field that made dirty-checking always pass

## Test plan

- [x] Configure split targets with a valid internal wallet and verify payments split correctly
- [x] Configure an LNURL target (lowercase `lnurl1...`) and verify it is accepted and paid
- [x] Send a very small payment (e.g. 1 sat with a 50% split) and verify the sub-1-sat target is skipped with a log warning rather than crashing
- [x] Configure one target as an invalid/deleted wallet and a second as valid — verify the second target still receives payment
- [x] Attempt to save targets with invalid wallet, self-split, or >100% total and verify the API returns a descriptive 400 error (not a 500)
- [x] Verify the frontend dirty indicator works correctly when adding/removing targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)